### PR TITLE
Keep key up to date in repeat binders

### DIFF
--- a/binders/repeat.js
+++ b/binders/repeat.js
@@ -46,6 +46,13 @@ module.exports = function() {
         } else {
           this.updateChanges(value, changes);
         }
+
+        // Keep the array indexesq updated as the array changes
+        if (Array.isArray(value) && this.keyName) {
+          this.views.forEach(function(view, i) {
+            view.context[this.keyName] = i;
+          }, this);
+        }
       }
     },
 


### PR DESCRIPTION
Taking what @dmvt started, putting it in a better place (to work for
animated lists too), using `keyName` rather than hard-coding `index`,
and setting it on the `context`. Supersedes #4. Thank you @dmvt for
submitting!
