### PR TITLE
Make p and br formatters not escape

### DIFF
--- a/formatters/br.js
+++ b/formatters/br.js
@@ -1,13 +1,11 @@
-var escapeHTML = require('./escape');
-
 /**
- * HTML escapes content adding <br> tags in place of newlines characters.
+ * Adds <br> tags in place of newlines characters.
  */
 module.exports = function(value, setter) {
   if (setter) {
-    return escapeHTML(value, setter);
+    return value.replace(/<br>\r?\n?/g, '\n');
   } else {
     var lines = (value || '').split(/\r?\n/);
-    return lines.map(escapeHTML).join('<br>\n');
+    return lines.join('<br>\n');
   }
 };

--- a/formatters/p.js
+++ b/formatters/p.js
@@ -1,14 +1,13 @@
-var escapeHTML = require('./escape');
-
 /**
- * HTML escapes content wrapping lines into paragraphs (in <p> tags).
+ * Wraps lines into paragraphs (in <p> tags).
  */
 module.exports = function(value, setter) {
   if (setter) {
-    return escapeHTML(value, setter);
+    return value.replace(/<p>\n?<\/p>/g, '\n').replace(/<p>|<\/p>/g, '');
   } else {
-    var lines = (value || '').split(/\r?\n/);
-    var escaped = lines.map(function(line) { return escapeHTML(line) || '<br>'; });
-    return '<p>' + escaped.join('</p>\n<p>') + '</p>';
+    var lines = (value || '').split(/\r?\n/)
+                // empty paragraphs will collapse if they don't have any content, insert a br
+                .map(function(line) { return line || '<br>'; });
+    return '<p>' + lines.join('</p>\n<p>') + '</p>';
   }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fragments-built-ins",
-  "version": "0.6.28",
+  "version": "0.6.29",
   "description": "Built-in binders, formatters, and animations for fragments.js-based frameworks.",
   "keywords": [
     "fragments-js"


### PR DESCRIPTION
Because many formatters may use escaped content, such as autolink,
escape should be explicit in its use. Don't auto-escape p or br, make
the dev escape explicitly.
