### PR TITLE
Fix property sort to handle nulls gracefully

### DIFF
--- a/formatters/sort.js
+++ b/formatters/sort.js
@@ -13,6 +13,9 @@ module.exports = function(value, sortFunc, dir) {
     dir2 = (dir2 === 'desc') ? -1 : 1;
     dir = dir || dir2;
     sortFunc = function(a, b) {
+      if (a && !b) return dir;
+      if (!a && b) return -dir;
+      if (!a && !b) return 0;
       if (a[prop] > b[prop]) return dir;
       if (a[prop] < b[prop]) return -dir;
       return 0;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fragments-built-ins",
-  "version": "0.6.37",
+  "version": "0.6.38",
   "description": "Built-in binders, formatters, and animations for fragments.js-based frameworks.",
   "keywords": [
     "fragments-js"


### PR DESCRIPTION
If a null occurred a breaking JavaScript exception would be thrown.
This handles nulls gracefully.
