### PR TITLE
Fix exception in `if` binder

### DIFF
--- a/binders/if.js
+++ b/binders/if.js
@@ -86,6 +86,8 @@ module.exports = function(elseIfAttrName, elseAttrName, unlessAttrName, elseUnle
     },
 
     updatedRegular: function(index) {
+      this.animating = false;
+
       if (this.showing) {
         this.remove(this.showing);
         this.showing = null;
@@ -100,8 +102,10 @@ module.exports = function(elseIfAttrName, elseAttrName, unlessAttrName, elseUnle
     updatedAnimated: function(index) {
       this.lastValue = index;
       if (this.animating) {
-        // Obsoleted, will change after animation is finished.
-        this.showing.unbind();
+        if (this.showing) {
+          // Obsoleted, will change after animation is finished.
+          this.showing.unbind();
+        }
         return;
       }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fragments-built-ins",
-  "version": "0.6.46",
+  "version": "0.6.47",
   "description": "Built-in binders, formatters, and animations for fragments.js-based frameworks.",
   "keywords": [
     "fragments-js"


### PR DESCRIPTION
We found that there may be a case when `animating` is `true`, but
`showing` is `null`. Not sure how this happens, but this patches that
up by setting `animating` to `false` when running through
`updatedRegular`, and checks for `showing` before calling unbind.