### PR TITLE
fix insertBefore type error

### DIFF
--- a/binders/if.js
+++ b/binders/if.js
@@ -75,9 +75,11 @@ module.exports = function(elseIfAttrName, elseAttrName, unlessAttrName, elseUnle
     },
 
     add: function(view) {
-      view.bind(this.context);
-      this.element.parentNode.insertBefore(view, this.element.nextSibling);
-      view.attached();
+      if (this.element && this.element.parentNode && this.element.nextSibling) {
+        view.bind(this.context);
+        this.element.parentNode.insertBefore(view, this.element.nextSibling);
+        view.attached();
+      }
     },
 
     // Doesn't do much, but allows sub-classes to alter the functionality.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fragments-built-ins",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Built-in binders, formatters, and animations for fragments.js-based frameworks.",
   "keywords": [
     "fragments-js"


### PR DESCRIPTION
It's possible for `this.element.parentNode` to be `undefined` when this is called, so I added some extra checks to avoid type errors.